### PR TITLE
Add some cross-endpoint consistency checks

### DIFF
--- a/ckanfunctionaltests/api/test_organizations.py
+++ b/ckanfunctionaltests/api/test_organizations.py
@@ -16,18 +16,19 @@ def test_organization_show_404(base_url, rsession):
     assert response.json()["success"] is False
 
 
-def test_organization_show(base_url, rsession, random_org_slug):
+def test_organization_show(subtests, base_url, rsession, random_org_slug):
     response = rsession.get(f"{base_url}/action/organization_show?id={random_org_slug}")
     assert response.status_code == 200
-
     rj = response.json()
-    validate_against_schema(rj, "organization_show.schema.json")
 
-    assert rj["success"] is True
-    assert rj["result"]["name"] == random_org_slug
+    with subtests.test("response validity"):
+        validate_against_schema(rj, "organization_show.schema.json")
 
-    # we should be able to look up this same organization by its uuid and get an identical response
-    uuid_response = rsession.get(f"{base_url}/action/organization_show?id={rj['result']['id']}")
-    assert uuid_response.status_code == 200
-    assert uuid_response.json() == rj
+        assert rj["success"] is True
+        assert rj["result"]["name"] == random_org_slug
 
+    with subtests.test("uuid lookup consistency"):
+        # we should be able to look up this same organization by its uuid and get an identical response
+        uuid_response = rsession.get(f"{base_url}/action/organization_show?id={rj['result']['id']}")
+        assert uuid_response.status_code == 200
+        assert uuid_response.json() == rj

--- a/ckanfunctionaltests/api/test_packages.py
+++ b/ckanfunctionaltests/api/test_packages.py
@@ -1,3 +1,5 @@
+from dmtestutils.comparisons import AnySupersetOf
+
 from ckanfunctionaltests.api import validate_against_schema
 
 
@@ -16,19 +18,27 @@ def test_package_show_404(base_url, rsession):
     assert response.json()["success"] is False
 
 
-def test_package_show(base_url, rsession, random_pkg_slug):
+def test_package_show(subtests, base_url, rsession, random_pkg_slug):
     response = rsession.get(f"{base_url}/action/package_show?id={random_pkg_slug}")
     assert response.status_code == 200
-
     rj = response.json()
-    validate_against_schema(rj, "package_show.schema.json")
 
-    assert rj["success"] is True
-    assert rj["result"]["name"] == random_pkg_slug
-    assert all(res["package_id"] == rj['result']['id'] for res in rj["result"]["resources"])
-    assert rj["result"]["num_resources"] == len(rj["result"]["resources"])
+    with subtests.test("response validity"):
+        validate_against_schema(rj, "package_show.schema.json")
+        assert rj["success"] is True
+        assert rj["result"]["name"] == random_pkg_slug
+        assert all(res["package_id"] == rj['result']['id'] for res in rj["result"]["resources"])
+        assert rj["result"]["num_resources"] == len(rj["result"]["resources"])
 
-    # we should be able to look up this same package by its uuid and get an identical response
-    uuid_response = rsession.get(f"{base_url}/action/package_show?id={rj['result']['id']}")
-    assert uuid_response.status_code == 200
-    assert uuid_response.json() == rj
+    with subtests.test("uuid lookup consistency"):
+        # we should be able to look up this same package by its uuid and get an identical response
+        uuid_response = rsession.get(f"{base_url}/action/package_show?id={rj['result']['id']}")
+        assert uuid_response.status_code == 200
+        assert uuid_response.json() == rj
+
+    with subtests.test("organization consistency"):
+        org_response = rsession.get(
+            f"{base_url}/action/organization_show?id={rj['result']['organization']['id']}"
+        )
+        assert org_response.status_code == 200
+        assert org_response.json()["result"] == AnySupersetOf(rj['result']['organization'])

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "api_base_url": "https://ckan.publishing.service.gov.uk/api",
+    "api_base_url": "https://ckan.staging.publishing.service.gov.uk/api",
     "api_user_agent": "ckan-functional-tests"
 }

--- a/default.nix
+++ b/default.nix
@@ -26,9 +26,8 @@ in (with args; {
       pythonPackages.python
       sitePrioNonNix
       pkgs.glibcLocales
-      # for `cryptography`
-#       pkgs.openssl
-#       pkgs.cacert
+      # some requirements are installed via git
+      pkgs.git
     ];
 
     hardeningDisable = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "format" ];

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,8 +19,9 @@ pluggy==0.13.1            # via -r requirements.txt, pytest
 py==1.8.1                 # via -r requirements.txt, pytest
 pyparsing==2.4.6          # via -r requirements.txt, packaging
 pyrsistent==0.15.7        # via -r requirements.txt, jsonschema
+pytest-subtests==0.3.0    # via -r requirements.txt
 pytest-variables==1.9.0   # via -r requirements.txt
-pytest==5.4.1             # via -r requirements.txt, pytest-variables
+pytest==5.4.1             # via -r requirements.txt, pytest-subtests, pytest-variables
 requests==2.23.0          # via -r requirements.txt
 six==1.14.0               # via -r requirements.txt, jsonschema, packaging, pip-tools, pyrsistent
 urllib3==1.25.8           # via -r requirements.txt, requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ attrs==19.3.0             # via -r requirements.txt, jsonschema, pytest
 certifi==2019.11.28       # via -r requirements.txt, requests
 chardet==3.0.4            # via -r requirements.txt, requests
 click==7.1.1              # via pip-tools
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2  # via -r requirements.txt
 idna==2.9                 # via -r requirements.txt, requests
 importlib-metadata==1.5.0  # via -r requirements.txt, jsonschema, pluggy, pytest
 jsonschema==3.2.0         # via -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@ pytest>=5,<6
 pytest-variables>=1.9,<2
 requests>=2.23,<2.24
 jsonschema>=3.2,<3.3
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 pytest>=5,<6
 pytest-variables>=1.9,<2
+pytest-subtests>=0.3,<0.4
 requests>=2.23,<2.24
 jsonschema>=3.2,<3.3
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,9 @@ pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pyparsing==2.4.6          # via packaging
 pyrsistent==0.15.7        # via jsonschema
+pytest-subtests==0.3.0    # via -r requirements.in
 pytest-variables==1.9.0   # via -r requirements.in
-pytest==5.4.1             # via -r requirements.in, pytest-variables
+pytest==5.4.1             # via -r requirements.in, pytest-subtests, pytest-variables
 requests==2.23.0          # via -r requirements.in
 six==1.14.0               # via jsonschema, packaging, pyrsistent
 urllib3==1.25.8           # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 attrs==19.3.0             # via jsonschema, pytest
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.2#egg=digitalmarketplace-test-utils==2.6.2  # via -r requirements.in
 idna==2.9                 # via requests
 importlib-metadata==1.5.0  # via jsonschema, pluggy, pytest
 jsonschema==3.2.0         # via -r requirements.in


### PR DESCRIPTION
https://trello.com/c/qG6O72lh

This uses `pytest-subtests`, which is a pretty neat way of reducing unnecessary repeated work that would end up being done if written as separate tests, even if they shared setup code using fixtures.

I've also pulled in `digitalmarketplace-test-utils` for the moment so I can use its `comparisons`. Specifically I use `AnySubsetOf` in the `package` -> `organization` cross-check test.