### PR TITLE
add tests of package_search endpoint

### DIFF
--- a/ckanfunctionaltests/api/conftest.py
+++ b/ckanfunctionaltests/api/conftest.py
@@ -1,4 +1,5 @@
 from random import Random
+import re
 
 import pytest
 import requests
@@ -6,6 +7,9 @@ import requests
 
 # we will want to be able to seed this at some point
 _random = Random()
+
+
+_uuid_re = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
 
 
 @pytest.fixture()
@@ -29,6 +33,23 @@ def random_org_slug(base_url, rsession):
 
 @pytest.fixture()
 def random_pkg_slug(base_url, rsession):
-    response = rsession.get(f"{base_url}/action/package_list")
+    # make do with one of the first 200 because the full list is big & slow
+    response = rsession.get(f"{base_url}/action/package_list?limit=200")
     assert response.status_code == 200
-    return _random.choice(response.json()["result"])
+
+    suitable_names = tuple(
+        name for name in response.json()["result"] if not _uuid_re.fullmatch(name)
+    )
+
+    if not suitable_names:
+        raise ValueError("No suitable package slugs found")
+
+    return _random.choice(suitable_names)
+
+
+@pytest.fixture()
+def random_pkg(base_url, rsession, random_pkg_slug):
+    response = rsession.get(f"{base_url}/action/package_show?id={random_pkg_slug}")
+    assert response.status_code == 200
+
+    return response.json()["result"]

--- a/ckanfunctionaltests/api/schemas/package_show.schema.json
+++ b/ckanfunctionaltests/api/schemas/package_show.schema.json
@@ -25,7 +25,7 @@
         },
         "type": {
           "type": "string",
-          "const": "dataset"
+          "enum": ["dataset", "harvest"]
         },
         "groups": {
           "type": "array",
@@ -196,7 +196,6 @@
         "private",
         "name",
         "creator_user_id",
-        "isopen",
         "owner_org",
         "organization"
       ]

--- a/ckanfunctionaltests/api/test_packages.py
+++ b/ckanfunctionaltests/api/test_packages.py
@@ -1,3 +1,6 @@
+import re
+from warnings import warn
+
 from dmtestutils.comparisons import AnySupersetOf
 
 from ckanfunctionaltests.api import validate_against_schema
@@ -41,3 +44,130 @@ def test_package_show(subtests, base_url, rsession, random_pkg_slug):
         )
         assert org_response.status_code == 200
         assert org_response.json()["result"] == AnySupersetOf(rj['result']['organization'])
+
+
+def test_package_search_by_full_slug_general_term(subtests, base_url, rsession, random_pkg_slug):
+    response = rsession.get(
+        f"{base_url}/action/package_search?q={random_pkg_slug}&rows=100"
+    )
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+
+    desired_result = tuple(
+        pkg for pkg in response.json()["result"]["results"] if pkg["name"] == random_pkg_slug
+    )
+    assert desired_result
+    if len(desired_result) > 1:
+        warn(f"Multiple results ({len(desired_result)}) with name = {random_pkg_slug!r})")
+
+    with subtests.test("approx consistency with package_show"):
+        ps_response = rsession.get(f"{base_url}/action/package_show?id={random_pkg_slug}")
+        assert ps_response.status_code == 200
+        assert any(ps_response.json()["result"]["id"] == result["id"] for result in desired_result)
+
+        # TODO assert actual contents are approximately equal (exact equality is out the window)
+
+
+def test_package_search_by_revision_id_specific_field(subtests, base_url, rsession, random_pkg):
+    response = rsession.get(
+        f"{base_url}/action/package_search?fq=revision_id:{random_pkg['revision_id']}"
+        "&rows=1000"
+    )
+    assert response.status_code == 200
+    rj = response.json()
+    assert rj["success"] is True
+
+    desired_result = tuple(
+        pkg for pkg in rj["result"]["results"] if pkg["id"] == random_pkg["id"]
+    )
+    assert len(desired_result) == 1
+
+    with subtests.test("all results match criteria"):
+        assert all(
+            random_pkg["revision_id"] == pkg["revision_id"] for pkg in rj["result"]["results"]
+        )
+
+    with subtests.test("approx consistency with package_show"):
+        assert random_pkg["name"] == desired_result[0]["name"]
+        assert random_pkg["organization"] == desired_result[0]["organization"]
+        # TODO assert actual contents are approximately equal (exact equality is out the window)
+
+
+_all_alpha_re = re.compile(r"[a-z]+", re.I)
+
+
+def _extract_search_terms(source_text: str, n: int) -> str:
+    """
+    choose n longest "clean" words from the source_text as our search terms (longer words
+    are more likely to be distinctive) and format them for use in a url
+    """
+    return "+".join(sorted(
+        (token for token in source_text.split() if _all_alpha_re.fullmatch(token)),
+        key=lambda t: len(t),
+        reverse=True,
+    )[:n])
+
+
+def test_package_search_by_org_id_specific_field_and_title_general_term(
+    subtests,
+    base_url,
+    rsession,
+    random_pkg,
+):
+    title_terms = _extract_search_terms(random_pkg["title"], 2)
+
+    response = rsession.get(
+        f"{base_url}/action/package_search?fq=owner_org:{random_pkg['owner_org']}"
+        f"&q={title_terms}&rows=1000"
+    )
+    assert response.status_code == 200
+    rj = response.json()
+    assert rj["success"] is True
+
+    with subtests.test("all results match criteria"):
+        assert all(
+            random_pkg["owner_org"] == pkg["owner_org"] for pkg in rj["result"]["results"]
+        )
+        # we can't reliably test for the search terms because they may have been stemmed
+        # and not correspond to exact matches
+
+    desired_result = tuple(
+        pkg for pkg in rj["result"]["results"] if pkg["id"] == random_pkg["id"]
+    )
+    if rj["result"]["count"] > 1000 and not desired_result:
+        # we don't have all results - it may well be on a latter page
+        warn(f"Expected package {random_pkg['id']!r} not found on first page of results")
+    else:
+        assert len(desired_result) == 1
+
+        with subtests.test("approx consistency with package_show"):
+            assert random_pkg["name"] == desired_result[0]["name"]
+            assert random_pkg["organization"] == desired_result[0]["organization"]
+            # TODO assert actual contents are approximately equal (exact equality is out the window)
+
+
+def test_package_search_facets(subtests, base_url, rsession, random_pkg):
+    notes_terms = _extract_search_terms(random_pkg["notes"], 2)
+
+    response = rsession.get(
+        f"{base_url}/action/package_search?q={notes_terms}&rows=10"
+        "&facet.field=[\"license_id\",\"organization\"]&facet.limit=-1"
+    )
+    assert response.status_code == 200
+    rj = response.json()
+    assert rj["success"] is True
+
+    with subtests.test("facets include random_pkg's value"):
+        assert random_pkg["organization"]["name"] in rj["result"]["facets"]["organization"]
+        assert any(
+            random_pkg["organization"]["name"] == val["name"]
+            for val in rj["result"]["search_facets"]["organization"]["items"]
+        )
+
+        # not all packages have a license_id
+        if random_pkg.get("license_id"):
+            assert random_pkg["license_id"] in rj["result"]["facets"]["license_id"]
+            assert any(
+                random_pkg["license_id"] == val["name"]
+                for val in rj["result"]["search_facets"]["license_id"]["items"]
+            )

--- a/ckanfunctionaltests/api/test_packages.py
+++ b/ckanfunctionaltests/api/test_packages.py
@@ -28,7 +28,6 @@ def test_package_show(subtests, base_url, rsession, random_pkg_slug):
         assert rj["success"] is True
         assert rj["result"]["name"] == random_pkg_slug
         assert all(res["package_id"] == rj['result']['id'] for res in rj["result"]["resources"])
-        assert rj["result"]["num_resources"] == len(rj["result"]["resources"])
 
     with subtests.test("uuid lookup consistency"):
         # we should be able to look up this same package by its uuid and get an identical response


### PR DESCRIPTION
https://trello.com/c/Drz1bW4s

These are _quite_ reliable, but not perfect, hence the use of warnings to tolerate weirdness.
