### PR TITLE
test endpoints also accessible under a api-versioned path, adapt to differences

### DIFF
--- a/ckanfunctionaltests/api/conftest.py
+++ b/ckanfunctionaltests/api/conftest.py
@@ -23,6 +23,12 @@ def base_url(variables):
     return variables["api_base_url"]
 
 
+@pytest.fixture(params=("", "/3"))
+def base_url_3(request, base_url):
+    "For endpoints published both under an /api and /api/3 endpoint"
+    return base_url + request.param
+
+
 @pytest.fixture()
 def inc_sync_sensitive(variables):
     """

--- a/ckanfunctionaltests/api/test_organizations.py
+++ b/ckanfunctionaltests/api/test_organizations.py
@@ -1,23 +1,23 @@
 from ckanfunctionaltests.api import validate_against_schema
 
 
-def test_organization_list(base_url, rsession):
-    response = rsession.get(f"{base_url}/action/organization_list")
+def test_organization_list(base_url_3, rsession):
+    response = rsession.get(f"{base_url_3}/action/organization_list")
     assert response.status_code == 200
     validate_against_schema(response.json(), "organization_list")
 
     assert response.json()["success"] is True
 
 
-def test_organization_show_404(base_url, rsession):
-    response = rsession.get(f"{base_url}/action/organization_show?id=number-three-group")
+def test_organization_show_404(base_url_3, rsession):
+    response = rsession.get(f"{base_url_3}/action/organization_show?id=number-three-group")
     assert response.status_code == 404
 
     assert response.json()["success"] is False
 
 
-def test_organization_show(subtests, base_url, rsession, random_org_slug):
-    response = rsession.get(f"{base_url}/action/organization_show?id={random_org_slug}")
+def test_organization_show(subtests, base_url_3, rsession, random_org_slug):
+    response = rsession.get(f"{base_url_3}/action/organization_show?id={random_org_slug}")
     assert response.status_code == 200
     rj = response.json()
 
@@ -29,6 +29,6 @@ def test_organization_show(subtests, base_url, rsession, random_org_slug):
 
     with subtests.test("uuid lookup consistency"):
         # we should be able to look up this same organization by its uuid and get an identical response
-        uuid_response = rsession.get(f"{base_url}/action/organization_show?id={rj['result']['id']}")
+        uuid_response = rsession.get(f"{base_url_3}/action/organization_show?id={rj['result']['id']}")
         assert uuid_response.status_code == 200
         assert uuid_response.json() == rj

--- a/ckanfunctionaltests/api/test_packages.py
+++ b/ckanfunctionaltests/api/test_packages.py
@@ -6,23 +6,23 @@ from dmtestutils.comparisons import AnySupersetOf
 from ckanfunctionaltests.api import validate_against_schema, extract_search_terms
 
 
-def test_package_list(base_url, rsession):
-    response = rsession.get(f"{base_url}/action/package_list")
+def test_package_list(base_url_3, rsession):
+    response = rsession.get(f"{base_url_3}/action/package_list")
     assert response.status_code == 200
     validate_against_schema(response.json(), "package_list")
 
     assert response.json()["success"] is True
 
 
-def test_package_show_404(base_url, rsession):
-    response = rsession.get(f"{base_url}/action/package_show?id=plates-knives-and-forks")
+def test_package_show_404(base_url_3, rsession):
+    response = rsession.get(f"{base_url_3}/action/package_show?id=plates-knives-and-forks")
     assert response.status_code == 404
 
     assert response.json()["success"] is False
 
 
-def test_package_show(subtests, base_url, rsession, random_pkg_slug):
-    response = rsession.get(f"{base_url}/action/package_show?id={random_pkg_slug}")
+def test_package_show(subtests, base_url_3, rsession, random_pkg_slug):
+    response = rsession.get(f"{base_url_3}/action/package_show?id={random_pkg_slug}")
     assert response.status_code == 200
     rj = response.json()
 
@@ -34,13 +34,13 @@ def test_package_show(subtests, base_url, rsession, random_pkg_slug):
 
     with subtests.test("uuid lookup consistency"):
         # we should be able to look up this same package by its uuid and get an identical response
-        uuid_response = rsession.get(f"{base_url}/action/package_show?id={rj['result']['id']}")
+        uuid_response = rsession.get(f"{base_url_3}/action/package_show?id={rj['result']['id']}")
         assert uuid_response.status_code == 200
         assert uuid_response.json() == rj
 
     with subtests.test("organization consistency"):
         org_response = rsession.get(
-            f"{base_url}/action/organization_show?id={rj['result']['organization']['id']}"
+            f"{base_url_3}/action/organization_show?id={rj['result']['organization']['id']}"
         )
         assert org_response.status_code == 200
         assert org_response.json()["result"] == AnySupersetOf(rj['result']['organization'])
@@ -49,12 +49,12 @@ def test_package_show(subtests, base_url, rsession, random_pkg_slug):
 def test_package_search_by_full_slug_general_term(
     subtests,
     inc_sync_sensitive,
-    base_url,
+    base_url_3,
     rsession,
     random_pkg_slug,
 ):
     response = rsession.get(
-        f"{base_url}/action/package_search?q={random_pkg_slug}&rows=100"
+        f"{base_url_3}/action/package_search?q={random_pkg_slug}&rows=100"
     )
     assert response.status_code == 200
     rj = response.json()
@@ -73,7 +73,9 @@ def test_package_search_by_full_slug_general_term(
             warn(f"Multiple results ({len(desired_result)}) with name = {random_pkg_slug!r})")
 
         with subtests.test("approx consistency with package_show"):
-            ps_response = rsession.get(f"{base_url}/action/package_show?id={random_pkg_slug}")
+            ps_response = rsession.get(
+                f"{base_url_3}/action/package_show?id={random_pkg_slug}"
+            )
             assert ps_response.status_code == 200
             assert any(
                 ps_response.json()["result"]["id"] == result["id"] for result in desired_result
@@ -86,12 +88,12 @@ def test_package_search_by_full_slug_general_term(
 def test_package_search_by_revision_id_specific_field(
     subtests,
     inc_sync_sensitive,
-    base_url,
+    base_url_3,
     rsession,
     random_pkg,
 ):
     response = rsession.get(
-        f"{base_url}/action/package_search?fq=revision_id:{random_pkg['revision_id']}"
+        f"{base_url_3}/action/package_search?fq=revision_id:{random_pkg['revision_id']}"
         "&rows=1000"
     )
     assert response.status_code == 200
@@ -123,14 +125,14 @@ def test_package_search_by_revision_id_specific_field(
 def test_package_search_by_org_id_specific_field_and_title_general_term(
     subtests,
     inc_sync_sensitive,
-    base_url,
+    base_url_3,
     rsession,
     random_pkg,
 ):
     title_terms = extract_search_terms(random_pkg["title"], 2)
 
     response = rsession.get(
-        f"{base_url}/action/package_search?fq=owner_org:{random_pkg['owner_org']}"
+        f"{base_url_3}/action/package_search?fq=owner_org:{random_pkg['owner_org']}"
         f"&q={title_terms}&rows=1000"
     )
     assert response.status_code == 200
@@ -165,11 +167,11 @@ def test_package_search_by_org_id_specific_field_and_title_general_term(
                 # the window)
 
 
-def test_package_search_facets(subtests, inc_sync_sensitive, base_url, rsession, random_pkg):
+def test_package_search_facets(subtests, inc_sync_sensitive, base_url_3, rsession, random_pkg):
     notes_terms = extract_search_terms(random_pkg["notes"], 2)
 
     response = rsession.get(
-        f"{base_url}/action/package_search?q={notes_terms}&rows=10"
+        f"{base_url_3}/action/package_search?q={notes_terms}&rows=10"
         "&facet.field=[\"license_id\",\"organization\"]&facet.limit=-1"
     )
     assert response.status_code == 200

--- a/ckanfunctionaltests/api/test_paging.py
+++ b/ckanfunctionaltests/api/test_paging.py
@@ -9,8 +9,8 @@ import pytest
     # currently too slow to work
     #"/action/harvest_source_list?",
 ))
-def test_list_paging_equivalence(subtests, base_url, rsession, endpoint_path):
-    full_response = rsession.get(f"{base_url}{endpoint_path}")
+def test_list_paging_equivalence(subtests, base_url_3, rsession, endpoint_path):
+    full_response = rsession.get(f"{base_url_3}{endpoint_path}")
     assert full_response.status_code == 200
     assert full_response.json()["success"] is True
 
@@ -20,7 +20,7 @@ def test_list_paging_equivalence(subtests, base_url, rsession, endpoint_path):
         # tests for both heavily populated and sparsely populated instances
         limit = int(10 ** log_limit)
         response = rsession.get(
-            f"{base_url}{endpoint_path}&limit={limit}&offset={len(accumulated_results)}"
+            f"{base_url_3}{endpoint_path}&limit={limit}&offset={len(accumulated_results)}"
         )
         assert response.status_code == 200
         rj = response.json()
@@ -33,7 +33,7 @@ def test_list_paging_equivalence(subtests, base_url, rsession, endpoint_path):
             # no limit should return an equal result
             with subtests.test("offset no limit"):
                 response_no_lim = rsession.get(
-                    f"{base_url}{endpoint_path}&offset={len(accumulated_results)}"
+                    f"{base_url_3}{endpoint_path}&offset={len(accumulated_results)}"
                 )
                 assert response_no_lim.status_code == 200
                 assert rj == response_no_lim.json()
@@ -49,7 +49,7 @@ def test_list_paging_equivalence(subtests, base_url, rsession, endpoint_path):
 
     with subtests.test("no results past end"):
         overrun_response = rsession.get(
-            f"{base_url}{endpoint_path}&limit={limit}&offset={len(accumulated_results)+10}"
+            f"{base_url_3}{endpoint_path}&limit={limit}&offset={len(accumulated_results)+10}"
         )
         assert overrun_response.status_code == 200
         assert overrun_response.json()["success"] is True
@@ -65,11 +65,25 @@ def test_list_paging_equivalence(subtests, base_url, rsession, endpoint_path):
         "start",
     ),
     (
+        "/3/action/package_search?q=data",
+        lambda r: r["result"]["results"],
+        lambda r: r["result"]["count"],
+        "rows",
+        "start",
+    ),
+    (
         "/search/dataset?q=data",
         lambda r: r["results"],
         lambda r: r["count"],
         "limit",
         "offset",
+    ),
+    (
+        "/3/search/dataset?q=data",
+        lambda r: r["results"],
+        lambda r: r["count"],
+        "rows",
+        "start",
     ),
 ))
 def test_search_paging_equivalence(

--- a/ckanfunctionaltests/api/test_search_datasets.py
+++ b/ckanfunctionaltests/api/test_search_datasets.py
@@ -6,15 +6,20 @@ import pytest
 from ckanfunctionaltests.api import validate_against_schema, extract_search_terms
 
 
+def _get_limit_offset_params(base_url):
+    return ("rows", "start",) if base_url.endswith("/3") else ("limit", "offset",)
+
+
 def test_search_datasets_by_full_slug_general_term(
     subtests,
     inc_sync_sensitive,
-    base_url,
+    base_url_3,
     rsession,
     random_pkg_slug,
 ):
+    limit_param, offset_param = _get_limit_offset_params(base_url_3)
     response = rsession.get(
-        f"{base_url}/search/dataset?q={random_pkg_slug}&rows=100"
+        f"{base_url_3}/search/dataset?q={random_pkg_slug}&{limit_param}=100"
     )
     assert response.status_code == 200
     rj = response.json()
@@ -38,12 +43,13 @@ def test_search_datasets_by_full_slug_general_term(
 def test_search_datasets_by_full_slug_general_term_id_response(
     subtests,
     inc_sync_sensitive,
-    base_url,
+    base_url_3,
     rsession,
     random_pkg,
 ):
+    limit_param, offset_param = _get_limit_offset_params(base_url_3)
     response = rsession.get(
-        f"{base_url}/search/dataset?q={random_pkg['name']}&fl=id&rows=100"
+        f"{base_url_3}/search/dataset?q={random_pkg['name']}&fl=id&{limit_param}=100"
     )
     assert response.status_code == 200
     rj = response.json()
@@ -62,12 +68,13 @@ def test_search_datasets_by_full_slug_general_term_id_response(
 def test_search_datasets_by_full_slug_general_term_revision_id_response(
     subtests,
     inc_sync_sensitive,
-    base_url,
+    base_url_3,
     rsession,
     random_pkg,
 ):
+    limit_param, offset_param = _get_limit_offset_params(base_url_3)
     response = rsession.get(
-        f"{base_url}/search/dataset?q={random_pkg['name']}&fl=revision_id&rows=100"
+        f"{base_url_3}/search/dataset?q={random_pkg['name']}&fl=revision_id&{limit_param}=100"
     )
     assert response.status_code == 200
     rj = response.json()
@@ -83,15 +90,21 @@ def test_search_datasets_by_full_slug_general_term_revision_id_response(
             assert any(random_pkg["revision_id"] == dst["revision_id"] for dst in rj["results"])
 
 
+@pytest.mark.parametrize("allfields_term", ("all_fields=1", "fl=*",))
 def test_search_datasets_by_full_slug_specific_field_all_fields_response(
     subtests,
     inc_sync_sensitive,
-    base_url,
+    base_url_3,
     rsession,
     random_pkg,
+    allfields_term,
 ):
+    if allfields_term.startswith("all_fields") and base_url_3.endswith("/3"):
+        pytest.skip("all_fields parameter not supported in v3 endpoint")
+
+    limit_param, offset_param = _get_limit_offset_params(base_url_3)
     response = rsession.get(
-        f"{base_url}/search/dataset?q=name:{random_pkg['name']}&all_fields=1&rows=10"
+        f"{base_url_3}/search/dataset?q=name:{random_pkg['name']}&{allfields_term}&{limit_param}=10"
     )
     assert response.status_code == 200
     rj = response.json()
@@ -117,11 +130,15 @@ def test_search_datasets_by_full_slug_specific_field_all_fields_response(
 def test_search_datasets_by_org_slug_specific_field_and_title_general_term(
     subtests,
     inc_sync_sensitive,
-    base_url,
+    base_url_3,
     rsession,
     random_pkg,
     org_as_q,
 ):
+    if base_url_3.endswith("/3") and not org_as_q:
+        pytest.skip("field filtering as separate params not supported in v3 endpoint")
+
+    limit_param, offset_param = _get_limit_offset_params(base_url_3)
     title_terms = extract_search_terms(random_pkg["title"], 2)
 
     # it's possible to query specific fields in two different ways
@@ -131,8 +148,8 @@ def test_search_datasets_by_org_slug_specific_field_and_title_general_term(
         f"&organization={random_pkg['organization']['name']}"
     )
     response = rsession.get(
-        f"{base_url}/search/dataset?{query_frag}"
-        "&fl=id,organization,title&rows=1000"
+        f"{base_url_3}/search/dataset?{query_frag}"
+        f"&fl=id,organization,title&{limit_param}=1000"
     )
     assert response.status_code == 200
     rj = response.json()


### PR DESCRIPTION
~This sits on top of #8 and #7, so ignore the earlier commits.~

https://trello.com/c/n1eopOny

Using parametrized fixtures to achieve this. There are a few differences between the parameters expected/supported by the unversioned and `/3/` endpoints. in some cases a feature/syntax is entirely unsupported - in these cases, skip that particular parameter combination.