### PR TITLE
test extended response options

### DIFF
--- a/ckanfunctionaltests/api/schemas/organization_base.schema.json
+++ b/ckanfunctionaltests/api/schemas/organization_base.schema.json
@@ -66,6 +66,21 @@
           }
         }
       }
+    },
+    "approval_status": {
+      "enum": ["pending", "approved"]
+    },
+    "package_count": {
+      "type": "integer"
+    },
+    "packages": {
+      "type": "array",
+      "items": {
+        "$ref": "package_base"
+      }
+    },
+    "num_followers": {
+      "type": "integer"
     }
   },
   "required": [

--- a/ckanfunctionaltests/api/schemas/organization_base.schema.json
+++ b/ckanfunctionaltests/api/schemas/organization_base.schema.json
@@ -4,9 +4,6 @@
   "title": "CKAN action api base organization representation",
   "type": "object",
   "properties": {
-    "package_count": {
-      "type": "integer"
-    },
     "id": {
       "type": "string",
       "format": "uuid"

--- a/ckanfunctionaltests/api/schemas/organization_list.schema.json
+++ b/ckanfunctionaltests/api/schemas/organization_list.schema.json
@@ -9,10 +9,18 @@
       "type": "object",
       "properties": {
         "result": {
-          "type": "array",
-          "items": {
-            "$ref": "common#/definitions/slug"
-          }
+          "anyOf": [{
+              "type": "array",
+              "items": {
+                "$ref": "common#/definitions/slug"
+              }
+            }, {
+              "type": "array",
+              "items": {
+                "$ref": "organization_base"
+              }
+            }
+          ]
         }
       }
     }

--- a/ckanfunctionaltests/api/test_organizations.py
+++ b/ckanfunctionaltests/api/test_organizations.py
@@ -1,12 +1,74 @@
+from dmtestutils.comparisons import AnySupersetOf
+
+
 from ckanfunctionaltests.api import validate_against_schema
 
 
 def test_organization_list(base_url_3, rsession):
     response = rsession.get(f"{base_url_3}/action/organization_list")
     assert response.status_code == 200
-    validate_against_schema(response.json(), "organization_list")
+    rj = response.json()
+    validate_against_schema(rj, "organization_list")
 
-    assert response.json()["success"] is True
+    assert rj["success"] is True
+    # assert this is the correct variant of the response
+    assert isinstance(rj["result"][0], str)
+
+
+def test_organization_list_all_fields(subtests, base_url_3, rsession):
+    response = rsession.get(f"{base_url_3}/action/organization_list?all_fields=1&limit=5")
+    assert response.status_code == 200
+    rj = response.json()
+
+    with subtests.test("response validity"):
+        validate_against_schema(rj, "organization_list")
+        assert rj["success"] is True
+        # assert this is the correct variant of the response schema
+        assert isinstance(rj["result"][0], dict)
+
+    with subtests.test("consistency with organization_show"):
+        os_response = rsession.get(f"{base_url_3}/action/organization_show?id={rj['result'][0]['id']}")
+        assert os_response.status_code == 200
+
+        assert os_response.json()["result"] == AnySupersetOf(rj['result'][0])
+
+
+def test_organization_list_all_fields_inc_optional(subtests, base_url_3, rsession):
+    response = rsession.get(
+        f"{base_url_3}/action/organization_list?all_fields=1&include_extras=1&include_tags=1"
+        "&include_groups=1&limit=5"
+    )
+    assert response.status_code == 200
+    rj = response.json()
+
+    with subtests.test("response validity"):
+        validate_against_schema(rj, "organization_list")
+        assert rj["success"] is True
+        # assert this is the correct variant of the response schema
+        assert isinstance(rj["result"][0], dict)
+        assert "extras" in rj["result"][0]
+        assert "tags" in rj["result"][0]
+        assert "groups" in rj["result"][0]
+
+    with subtests.test("consistency with organization_show"):
+        os_response = rsession.get(f"{base_url_3}/action/organization_show?id={rj['result'][0]['id']}")
+        assert os_response.status_code == 200
+
+        assert os_response.json()["result"] == AnySupersetOf(rj['result'][0])
+
+
+def test_organization_list_all_fields_inc_users_no_effect(subtests, base_url_3, rsession):
+    incusers_response = rsession.get(
+        f"{base_url_3}/action/organization_list?all_fields=1&include_users=1&limit=5"
+    )
+    assert incusers_response.status_code == 200
+
+    excusers_response = rsession.get(
+        f"{base_url_3}/action/organization_list?all_fields=1&include_users=0&limit=5"
+    )
+    assert excusers_response.status_code == 200
+
+    assert incusers_response.json() == excusers_response.json()
 
 
 def test_organization_show_404(base_url_3, rsession):

--- a/ckanfunctionaltests/api/test_packages.py
+++ b/ckanfunctionaltests/api/test_packages.py
@@ -46,6 +46,17 @@ def test_package_show(subtests, base_url_3, rsession, random_pkg_slug):
         assert org_response.json()["result"] == AnySupersetOf(rj['result']['organization'])
 
 
+def test_package_show_default_schema(base_url_3, rsession, random_pkg_slug):
+    response = rsession.get(
+        f"{base_url_3}/action/package_show?id={random_pkg_slug}&use_default_schema=1"
+    )
+    assert response.status_code == 200
+    rj = response.json()
+    validate_against_schema(rj, "package_show")
+
+    assert rj["success"] is True
+
+
 def test_package_search_by_full_slug_general_term(
     subtests,
     inc_sync_sensitive,


### PR DESCRIPTION
This sits on top of ~#8 and~ #9

https://trello.com/c/zEZyAh7e

This ends up adding tests for the extended response forms of the `organization_list`, `organization_show` and `package_show` endpoints. For `package_show` it adds tests for the `use_default_schema` mode, which unfortunately bypasses the PII filter we had put in place. For now we just ensure this response complies to the general `package_base` schema, but once we have fixed this problem we should attempt to detect undesirable PII fields in the schema and fail them.
