### PR TITLE
Fix test_organization_show_inc_datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,20 @@ used to treat these warnings as test failures.
 There are also some combinations of parametrization values which will always be skipped (because
 they are combinations of features which are not supported). These are nothing to worry about
 either - it's just that using `pytest.skip` was the least bad way of omitting these cases.
+
+## Troubleshooting
+
+If some tests are failing because of the mock harvest source not matching then it's likely that 
+the `vars.conf` was not updated in nginx in the `static-mock-harvest-source` container. 
+Run these commands to fix it without having to rebuild the `static-mock-harvest-source` image -
+
+  docker exec -it static-mock-harvest-source bash
+  echo $'\nmap $host $mock_absolute_root_url { default "http://static-mock-harvest-source:11088/"; }' >> /etc/nginx/vars.conf
+  service nginx reload
+
+To make these changes more permanent add this to the end of `vars.conf` in the relevant source file if `bootstrap.sh`
+didn't update it, which can happen if you checked out a different branch on the `ckan-mock-harvest-sources` repo -
+
+  map $host $mock_absolute_root_url { default "http://static-mock-harvest-source:11088/"; }
+
+and then run the `./scripts/rebuild-ckan.sh 2.7` script (substitute 2.7 for the version you want to rebuild).

--- a/ckanfunctionaltests/api/test_organizations.py
+++ b/ckanfunctionaltests/api/test_organizations.py
@@ -130,9 +130,9 @@ def test_organization_show_inc_datasets_stable_pkg(
     with subtests.test("response validity"):
         validate_against_schema(rj, "organization_show")
 
-    desired_result = tuple(
-        pkg for pkg in rj["result"]["packages"] if pkg["organization"]["name"] == stable_org_with_datasets["name"]
-    )
+    desired_result = [
+        clean_unstable_elements(pkg) for pkg in rj["result"]["packages"] if pkg["organization"]["name"] == stable_org_with_datasets["name"]
+    ]
     if rj["result"]["package_count"] > 1000 and not desired_result:
         # this view only shows the first 1000 packages - it may have missed the cut
         warn(f"Expected package name {stable_org_with_datasets['name']!r} not found in first 1000 listed packages")
@@ -141,6 +141,5 @@ def test_organization_show_inc_datasets_stable_pkg(
         assert len(desired_result) == 2
 
         with subtests.test("response equality"):
-            clean_unstable_elements(desired_result[0])
             clean_unstable_elements(stable_org_with_datasets["packages"][0])
-            assert desired_result[0] == stable_org_with_datasets["packages"][0]
+            assert stable_org_with_datasets["packages"][0] in desired_result


### PR DESCRIPTION
## What

Problem was that the example dataset harvested is not guaranteed to be the first dataset shown in the API call.
So it has been fixed so that it shouldn't matter if `example-dataset-number-one` is first or second in the list.

The README was also updated to help fix tests where the harvest source was not matching.