### PR TITLE
Fix tests puppet stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ notably this includes:
    considered "stable" to compare with results from the target. You may want to do so if e.g.
    your target instance is only filled with sparse demo data.
 
+To run against CKAN in Integration:
+
+ - `username`: set the basic auth username on the Integration environment.
+ - `password`: set the basic auth password on the Integration environment.
+
 ## Warnings
 
 This test suite _will_ emit warnings if it is unable to complete an assertion for reasons that

--- a/README.md
+++ b/README.md
@@ -80,9 +80,11 @@ If some tests are failing because of the mock harvest source not matching then i
 the `vars.conf` was not updated in nginx in the `static-mock-harvest-source` container. 
 Run these commands to fix it without having to rebuild the `static-mock-harvest-source` image -
 
-  docker exec -it static-mock-harvest-source bash
-  echo $'\nmap $host $mock_absolute_root_url { default "http://static-mock-harvest-source:11088/"; }' >> /etc/nginx/vars.conf
-  service nginx reload
+```
+docker exec -it static-mock-harvest-source bash
+echo $'\nmap $host $mock_absolute_root_url { default "http://static-mock-harvest-source:11088/"; }' >> /etc/nginx/vars.conf
+service nginx reload
+```
 
 To make these changes more permanent add this to the end of `vars.conf` in the relevant source file if `bootstrap.sh`
 didn't update it, which can happen if you checked out a different branch on the `ckan-mock-harvest-sources` repo -

--- a/ckanfunctionaltests/api/conftest.py
+++ b/ckanfunctionaltests/api/conftest.py
@@ -131,6 +131,8 @@ _unstable_keys = frozenset((
     "package_id",
     "revision_id",
     "validated_data_dict",
+    "index_id",
+    "site_id"
 ))
 
 

--- a/ckanfunctionaltests/api/test_harvestobject.py
+++ b/ckanfunctionaltests/api/test_harvestobject.py
@@ -5,10 +5,11 @@ from xml.etree.ElementTree import fromstring
 import pytest
 
 
-def test_harvestobject_xml(inc_sync_sensitive, base_url, rsession, random_harvestobject_id):
+def test_harvestobject_xml(variables, inc_sync_sensitive, base_url, rsession, random_harvestobject_id):
     if not inc_sync_sensitive:
         pytest.skip("it's possible for some harvest objects to be missing")
 
+    rsession.auth = (variables['username'], variables['password'])
     response = rsession.get(f"{base_url}/2/rest/harvestobject/{random_harvestobject_id}/xml")
     assert response.status_code == 200
 

--- a/config.json
+++ b/config.json
@@ -3,6 +3,6 @@
     "api_user_agent": "ckan-functional-tests",
     "inc_sync_sensitive": true,
     "inc_fixed_data": true,
-    "username": "< username for integration >",
-    "password": "< password for integration >"
+    "username": "< basic auth username for integration >",
+    "password": "< basic auth password for integration >"
 }

--- a/config.json
+++ b/config.json
@@ -2,5 +2,7 @@
     "api_base_url": "https://ckan.staging.publishing.service.gov.uk/api",
     "api_user_agent": "ckan-functional-tests",
     "inc_sync_sensitive": true,
-    "inc_fixed_data": true
+    "inc_fixed_data": true,
+    "username": "< username for integration >",
+    "password": "< password for integration >"
 }


### PR DESCRIPTION
## What

In order to get the tests to pass on the puppet stacks additional fields need to be added to the unstable keys list and in order to run the tests against the Integration environment the username and password needs to be set.

## Reference

https://trello.com/c/JK5YYX4H/259-get-functional-tests-running-properly-on-integration