### PR TITLE
Fix tests revision

### DIFF
--- a/ckanfunctionaltests/api/test_organizations.py
+++ b/ckanfunctionaltests/api/test_organizations.py
@@ -18,7 +18,6 @@ def test_organization_list(base_url_3, rsession):
     assert isinstance(rj["result"][0], str)
 
 
-@pytest.mark.skip()
 def test_organization_list_all_fields(subtests, base_url_3, rsession):
     response = rsession.get(f"{base_url_3}/action/organization_list?all_fields=1&limit=5")
     assert response.status_code == 200
@@ -37,7 +36,6 @@ def test_organization_list_all_fields(subtests, base_url_3, rsession):
         assert os_response.json()["result"] == AnySupersetOf(rj['result'][0])
 
 
-@pytest.mark.skip()
 def test_organization_list_all_fields_inc_optional(subtests, base_url_3, rsession):
     response = rsession.get(
         f"{base_url_3}/action/organization_list?all_fields=1&include_extras=1&include_tags=1"
@@ -64,7 +62,6 @@ def test_organization_list_all_fields_inc_optional(subtests, base_url_3, rsessio
         assert os_response.json()["result"] == AnySupersetOf(rj['result'][0])
 
 
-@pytest.mark.skip()
 def test_organization_list_all_fields_inc_users_no_effect(subtests, base_url_3, rsession):
     incusers_response = rsession.get(
         f"{base_url_3}/action/organization_list?all_fields=1&include_users=1&limit=5"
@@ -86,7 +83,6 @@ def test_organization_show_404(base_url_3, rsession):
     assert response.json()["success"] is False
 
 
-@pytest.mark.skip()
 def test_organization_show(subtests, base_url_3, rsession, random_org_slug):
     response = rsession.get(f"{base_url_3}/action/organization_show?id={random_org_slug}")
     assert response.status_code == 200
@@ -105,7 +101,6 @@ def test_organization_show(subtests, base_url_3, rsession, random_org_slug):
         assert uuid_response.json() == rj
 
 
-@pytest.mark.skip()
 def test_organization_show_stable_org(subtests, base_url_3, rsession, stable_org):
     response = rsession.get(
         f"{base_url_3}/action/organization_show?id={stable_org['name']}"
@@ -120,7 +115,6 @@ def test_organization_show_stable_org(subtests, base_url_3, rsession, stable_org
         assert rj["result"] == AnySupersetOf(stable_org, recursive=True, seq_norm_order=True)
 
 
-@pytest.mark.skip()
 def test_organization_show_inc_datasets_stable_pkg(
     subtests,
     base_url_3,

--- a/ckanfunctionaltests/api/test_packages.py
+++ b/ckanfunctionaltests/api/test_packages.py
@@ -26,7 +26,6 @@ def test_package_show_404(base_url_3, rsession):
     assert response.json()["success"] is False
 
 
-@pytest.mark.skip()
 def test_package_show(subtests, base_url_3, rsession, random_pkg_slug):
     response = rsession.get(f"{base_url_3}/action/package_show?id={random_pkg_slug}")
     assert response.status_code == 200
@@ -52,7 +51,6 @@ def test_package_show(subtests, base_url_3, rsession, random_pkg_slug):
         assert org_response.json()["result"] == AnySupersetOf(rj['result']['organization'], recursive=True)
 
 
-@pytest.mark.skip()
 def test_package_show_default_schema(base_url_3, rsession, stable_pkg):
     # cannot use random slugs as they sometimes contain harvest packages which cannot be handled properly
     response = rsession.get(
@@ -65,7 +63,6 @@ def test_package_show_default_schema(base_url_3, rsession, stable_pkg):
     assert rj["success"] is True
 
 
-@pytest.mark.skip()
 def test_package_show_stable_pkg(subtests, base_url_3, rsession, stable_pkg):
     response = rsession.get(
         f"{base_url_3}/action/package_show?id={stable_pkg['name']}"
@@ -83,7 +80,6 @@ def test_package_show_stable_pkg(subtests, base_url_3, rsession, stable_pkg):
         assert rj["result"] == AnySupersetOf(stable_pkg, recursive=True, seq_norm_order=True)
 
 
-@pytest.mark.skip()
 def test_package_show_stable_pkg_default_schema(
     subtests,
     base_url_3,
@@ -108,7 +104,6 @@ def test_package_show_stable_pkg_default_schema(
         assert rj["result"] == AnySupersetOf(stable_pkg_default_schema, recursive=True, seq_norm_order=True)
 
 
-@pytest.mark.skip()
 def test_package_search_by_full_slug_general_term(
     subtests,
     inc_sync_sensitive,
@@ -189,7 +184,6 @@ def test_package_search_by_revision_id_specific_field(
             # window)
 
 
-@pytest.mark.skip()
 def test_package_search_by_org_id_specific_field_and_title_general_term(
     subtests,
     inc_sync_sensitive,
@@ -237,7 +231,6 @@ def test_package_search_by_org_id_specific_field_and_title_general_term(
                 # TODO assert actual contents are approximately equal (exact equality is out
                 # the window)
 
-@pytest.mark.skip()
 def test_package_search_facets(subtests, inc_sync_sensitive, base_url_3, rsession, random_pkg):
     notes_terms = extract_search_terms(random_pkg["notes"], 2)
 
@@ -270,7 +263,6 @@ def test_package_search_facets(subtests, inc_sync_sensitive, base_url_3, rsessio
                 )
 
 
-@pytest.mark.skip()
 def test_package_search_stable_package(subtests, base_url_3, rsession, stable_pkg_search):
     stable_pkg = stable_pkg_search
     response = rsession.get(


### PR DESCRIPTION
## What

Update the tests so that they will show that the output for 2.9 is the expected output. In this case the `revision_id` has been removed from the responses and `metadata_modified` has been added to the resource elements.

## Reference 

https://trello.com/c/kE8YPBPT/2411-investigate-why-ckan-api-response-is-missing-revisionid