### PR TITLE
Fix more tests 2.9

### DIFF
--- a/ckanfunctionaltests/api/conftest.py
+++ b/ckanfunctionaltests/api/conftest.py
@@ -32,6 +32,12 @@ def base_url_3(request, base_url):
     return base_url + request.param
 
 
+def get_dataset_search_json_response(response, base_url_3, variables=None):
+    return response.json().get('result') if variables.get('ckan_version') == '2.9' and base_url_3.endswith("/3")\
+        else response.json()
+
+
+
 @pytest.fixture()
 def inc_sync_sensitive(variables):
     """
@@ -73,7 +79,7 @@ def random_pkg_slug(base_url, rsession):
     assert response.status_code == 200
 
     suitable_names = tuple(
-        name for name in response.json()["result"] if not uuid_re.fullmatch(name)
+        name for name in response.json()["result"] if not uuid_re.fullmatch(name) and not 'harvest' in name
     )
 
     if not suitable_names:

--- a/ckanfunctionaltests/api/schemas/dataset_base_2_9.schema.json
+++ b/ckanfunctionaltests/api/schemas/dataset_base_2_9.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://github.com/alphagov/ckan-functional-tests/api/dataset_base_2_9.schema.json",
+  "title": "CKAN legacy api base dataset representation",
+  "type": "object",
+  "properties": {
+    "creator_user_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "organization": {
+      "$ref": "organization_base"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "tag"
+      }
+    },
+    "isopen": {
+      "type": "boolean"
+    },
+    "license_id": {
+      "type": "string"
+    },
+    "license_title": {
+      "type": "string"
+    },
+    "license_url": {
+      "type": "string"
+    },
+    "state": {
+      "$ref": "common#/definitions/state"
+    },
+    "dataset_type": {
+      "type": "string"
+    },
+    "metadata_modified": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "metadata_created": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "indexed_ts": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "site_id": {
+      "type": "string"
+    },
+    "capacity": {
+      "type": "string"
+    },
+    "name": {
+      "$ref": "common#/definitions/slug"
+    },
+    "notes": {
+      "type": "string"
+    },
+    "num_resources": {
+      "type": "integer"
+    },
+    "num_tags": {
+      "type": "integer"
+    },
+    "private": {
+      "type": "boolean"
+    },
+    "title": {
+      "type": "string"
+    },
+    "extras": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/ckanfunctionaltests/api/schemas/search_dataset.schema.json
+++ b/ckanfunctionaltests/api/schemas/search_dataset.schema.json
@@ -18,6 +18,11 @@
           "items": {
             "$ref": "dataset_base"
           }
+        }, {
+          "type": "array",
+          "items": {
+            "$ref": "dataset_base_2_9"
+          }
         }
       ]
     }

--- a/ckanfunctionaltests/api/schemas/tag.schema.json
+++ b/ckanfunctionaltests/api/schemas/tag.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://github.com/alphagov/ckan-functional-tests/api/tag.schema.json",
+  "title": "CKAN legacy api base dataset representation",
+  "type": "object",
+  "properties": {
+    "display_name": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "name": {
+      "type": "string"
+    },
+    "state": {
+      "$ref": "common#/definitions/state"
+    },
+    "vocabulary_id": {
+      "anyOf": [{
+        "type": "null"
+      }, {
+        "type": "string",
+        "format": "uuid"
+      }
+    ]}
+  }
+}


### PR DESCRIPTION
## What

These tests were breaking for 2.9 because CKAN dropped support for v1 of the API endpoint which responded with the output with `results` at the root, now it resides under the `result` element. Also the output from the API endpoint produced a list of key value pairs when the field list was defined rather than strings in 2.8 which is a more consistent behaviour.

Other changes in the output were that `harvest` datasets no longer appear in package searches, but they still appear under package list, so there's probably some work to fix this inconsistency by CKAN and a schema for 2.9 was introduced as the response was significantly different from 2.7 and 2.8.

Some of the code was refactored to keep code changes to a minimal.

## Reference 

https://trello.com/c/unBcWMLi/2413-investigate-why-ckan-api-response-has-changed-so-that-results-sit-under-result-element