### PR TITLE
Update for 2.9.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,14 @@ Initially testing just the API.
 
 ## Setup CKAN variables
 
-In order to run the tests in docker CKAN using the CKAN static mock harvest source a number of manual steps need to take place:
-
-- Start up your (docker ckan stack)[https://github.com/alphagov/docker-ckan]
-- Create 2 publishers
-  - `Example Publisher #1` with `Charity` organisation type.
-  - `Example Publisher #2` with any organisation type.
-
-- Add the mock harvest source to CKAN
-  - url: `http://static-mock-harvest-source:11088`
-  - name: `Example Harvest #1`
-  - Source type: `CKAN`
-- After adding the harvest source start the harvest process by clicking on the reharvest button.
-
-- Edit `Example Dataset #1` to add in a Contact Name
-  - Contact name: `Example User`
-
-- Update the `ckan_vars.conf` file:
-
-  PACKAGE_ID=a18d2811-13b0-4838-8bfb-5793433317b9
-  MOCK_HARVEST_SOURCE_URL=http://static-mock-harvest-source:11088
-  OWNER_ORG=< Get the id from http://localhost:5000/api/3/action/organization_show?id=example-publisher-1 >
-
-  - PACKAGE_ID and MOCK_HARVEST_SOURCE_URL are the default values and should work unless you change the package in the ckan-static-mock-harvest-source, or need to run multiple stacks so the MOCK_HARVEST_SOURCE_URL could change.
-  - To find the `OWNER_ORG` go to this URL - http://localhost:5000/api/3/action/organization_show?id=example-publisher-1
-   - There should be just 1 result, the `OWNER_ORG` is the value in the `id` field.
+- Before running these tests you will need to setup the test data in CKAN by running `ckan datagovuk create-dgu-test-data` in the CKAN container. 
 
 - Update `config.json` to point to the CKAN website that you want to run the tests against.
   - make sure that you set the correct version of `ckan_version` as support for v1 API was dropped in 2.9.
+  - You may need to update the `ckan_mock_harvest_source` value in `config.json` if it has been remapped, the errors in the test results should give you a hint at the correct url which is normally running on port 11088. Other values that the tests need will be automatically generated in `ckan-vars.conf`. 
+  - If you tear down the CKAN stack and rebuild everything it is probably a good idea to delete `ckan-vars.conf` so that it gets regenerated with the latest values.
 
-After all these steps you should be able to run the tests.
+After these steps you should be able to run the tests.
 
 ## Installing & Running
 

--- a/ckanfunctionaltests/api/example_responses/stable/package_show-2.9.default_schema.inner.test.json
+++ b/ckanfunctionaltests/api/example_responses/stable/package_show-2.9.default_schema.inner.test.json
@@ -1,0 +1,205 @@
+{
+    "license_title": "UK Open Government Licence (OGL)",
+    "relationships_as_object": [],
+    "private": false,
+    "num_tags": 1,
+    "id": "<<PACKAGE_ID>>",
+    "metadata_created": "2020-06-19T16:18:51",
+    "owner_org": "45a0f852-88e5-4d71-962c-74e15c890e64",
+    "metadata_modified": "2020-06-22T14:21:39",
+    "state": "active",
+    "version": null,
+    "license_id": "uk-ogl",
+    "type": "dataset",
+    "resources": [
+    {
+        "cache_last_updated": null,
+        "cache_url": null,
+        "mimetype_inner": null,
+        "hash": "",
+        "description": "Example Dataset #1 - summary of findings",
+        "format": "PDF",
+        "url": "<<MOCK_HARVEST_SOURCE_URL>>/mock-third-party/example-dataset-1/findings.pdf",
+        "created": "2020-06-19T16:18:51",
+        "state": "active",
+        "package_id": "<<PACKAGE_ID>>",
+        "last_modified": null,
+        "mimetype": null,
+        "url_type": null,
+        "position": 0,
+        "revision_id": "10255b22-0c61-4764-a91c-ac26e3f57d45",
+        "size": null,
+        "id": "1c217a07-21f1-4e98-b4fa-f9d6009f4151",
+        "resource_type": null,
+        "name": null
+    },
+    {
+        "cache_last_updated": null,
+        "cache_url": null,
+        "mimetype_inner": null,
+        "hash": "",
+        "description": "Example Dataset #1 - benchmark",
+        "format": "PDF",
+        "url": "<<MOCK_HARVEST_SOURCE_URL>>/mock-third-party/example-dataset-1/benchmark.pdf",
+        "created": "2020-06-19T16:18:51.324516",
+        "state": "active",
+        "package_id": "<<PACKAGE_ID>>",
+        "last_modified": null,
+        "mimetype": null,
+        "url_type": null,
+        "position": 1,
+        "revision_id": "10255b22-0c61-4764-a91c-ac26e3f57d45",
+        "size": null,
+        "id": "9c32745b-d611-4d8c-bec0-4615fb9464d7",
+        "resource_type": null,
+        "name": null
+    },
+    {
+        "cache_last_updated": null,
+        "cache_url": null,
+        "mimetype_inner": null,
+        "hash": "",
+        "description": "Example Dataset #1 - summary of category scores (XLS)",
+        "format": "XLS",
+        "url": "<<MOCK_HARVEST_SOURCE_URL>>/mock-third-party/example-dataset-1/all-categories-summary.xls",
+        "created": "2020-06-19T16:18:51.324547",
+        "state": "active",
+        "package_id": "<<PACKAGE_ID>>",
+        "last_modified": null,
+        "mimetype": null,
+        "url_type": null,
+        "position": 2,
+        "revision_id": "10255b22-0c61-4764-a91c-ac26e3f57d45",
+        "size": null,
+        "id": "67eefa14-86de-4a3f-8fe3-3804ff08f8ce",
+        "resource_type": null,
+        "name": null
+    },
+    {
+        "cache_last_updated": null,
+        "cache_url": null,
+        "mimetype_inner": null,
+        "hash": "",
+        "description": "Example Dataset #1 - summary of category scores (CSV)",
+        "format": "CSV",
+        "url": "<<MOCK_HARVEST_SOURCE_URL>>/mock-third-party/example-dataset-1/all-categories-summary.csv",
+        "created": "2020-06-19T16:18:51",
+        "state": "active",
+        "package_id": "<<PACKAGE_ID>>",
+        "last_modified": null,
+        "mimetype": null,
+        "url_type": null,
+        "position": 3,
+        "revision_id": "10255b22-0c61-4764-a91c-ac26e3f57d45",
+        "size": null,
+        "id": "27ec6d83-7f13-4daf-ba90-227f4271d7f6",
+        "resource_type": null,
+        "name": null
+    }
+    ],
+    "num_resources": 4,
+    "tags": [
+    {
+        "vocabulary_id": null,
+        "state": "active",
+        "display_name": "example-data",
+        "id": "0883e992-af6d-4448-87eb-7505cca8b07c",
+        "name": "example-data"
+    }
+    ],
+    "groups": [],
+    "creator_user_id": "6cb0b1b6-08f4-4175-ac8b-1df27e701ef3",
+    "harvest": [
+    {
+        "value": "bf58c7a1-2b23-487d-bc5d-c8e2cf68e162",
+        "key": "harvest_object_id"
+    },
+    {
+        "value": "64e82f7f-7ce9-4e1a-93ab-8c972a0dd6a1",
+        "key": "harvest_source_id"
+    },
+    {
+        "value": "Example Harvest #1",
+        "key": "harvest_source_title"
+    }
+    ],
+    "relationships_as_subject": [],
+    "name": "example-dataset-number-one",
+    "isopen": true,
+    "url": "<<MOCK_HARVEST_SOURCE_URL>>/mock-third-party/example-dataset-1/about",
+    "notes": "This is an example CKAN dataset consisting of a number of active resources.",
+    "title": "Example Dataset #1",
+    "extras": [
+    {
+        "value": "",
+        "key": "codelist"
+    },
+    {
+        "value": "",
+        "key": "contact-email"
+    },
+    {
+        "value": "Example User",
+        "key": "contact-name"
+    },
+    {
+        "value": "",
+        "key": "contact-phone"
+    },
+    {
+        "value": "",
+        "key": "foi-email"
+    },
+    {
+        "value": "",
+        "key": "foi-name"
+    },
+    {
+        "value": "",
+        "key": "foi-phone"
+    },
+    {
+        "value": "",
+        "key": "foi-web"
+    },
+    {
+        "value": "",
+        "key": "licence-custom"
+    },
+    {
+        "value": "",
+        "key": "schema-vocabulary"
+    },
+    {
+        "value": "",
+        "key": "theme-primary"
+    },
+    {
+        "key": "harvest_object_id",
+        "value": "<<harvest_object_id-value>>"
+    },
+    {
+        "key": "harvest_source_id",
+        "value": "<<harvest_source_id-value>>"
+    },
+    {   
+        "key": "harvest_source_title", 
+        "value": "<<harvest_source_title-value>>"
+    }
+    ],
+    "license_url": "http://reference.data.gov.uk/id/open-government-licence",
+    "organization": {
+    "description": "",
+    "created": "2020-06-19T16:06:13",
+    "title": "Example Publisher #1",
+    "name": "example-publisher-1",
+    "is_organization": true,
+    "state": "active",
+    "image_url": "",
+    "revision_id": "d83459ac-9fdf-47cb-83b2-c228bedca780",
+    "type": "organization",
+    "id": "45a0f852-88e5-4d71-962c-74e15c890e64",
+    "approval_status": "approved"
+    },
+    "revision_id": "10255b22-0c61-4764-a91c-ac26e3f57d45"
+}

--- a/ckanfunctionaltests/api/example_responses/stable/search_dataset-2.9.inner.test.json
+++ b/ckanfunctionaltests/api/example_responses/stable/search_dataset-2.9.inner.test.json
@@ -42,10 +42,7 @@
     "url": "<<MOCK_HARVEST_SOURCE_URL>>/mock-third-party/example-dataset-1/about",
     "notes": "This is an example CKAN dataset consisting of a number of active resources.",
     "title": "Example Dataset #1",
-    "harvest_object_id": "bf58c7a1-2b23-487d-bc5d-c8e2cf68e162",
     "contact-name": "Example User",
-    "harvest_source_title": "Example Harvest #1",
-    "harvest_source_id": "64e82f7f-7ce9-4e1a-93ab-8c972a0dd6a1",
     "organization": "example-publisher-1",
     "index_id": "78a56565b87a9c722e4893ef9bfe4a06"
 }

--- a/config.json
+++ b/config.json
@@ -1,9 +1,11 @@
 {
-    "api_base_url": "https://ckan.staging.publishing.service.gov.uk/api",
-    "ckan_version": "2.8",
+    "api_base_url": "http://localhost:8080/api",
+    "ckan_version": "2.9",
     "api_user_agent": "ckan-functional-tests",
     "inc_sync_sensitive": true,
     "inc_fixed_data": true,
     "username": "< basic auth username for integration >",
-    "password": "< basic auth password for integration >"
+    "password": "< basic auth password for integration >",
+    "ckan_vars": "PACKAGE_ID=a18d2811-13b0-4838-8bfb-5793433317b9,OWNER_ORG=FROM_API:/3/action/organization_show?id=example-publisher-1",
+    "ckan_mock_harvest_source": "http://127.0.0.1:11088"  
 }


### PR DESCRIPTION
## What

Update of the functional tests to enable them to run and pass with CKAN 2.9.7

## Reference 

https://trello.com/c/dubv8VPR/1102-fix-ckan-functional-tests-when-running-against-local-ckan-k8s-cluster